### PR TITLE
Use new API of ClassAdded

### DIFF
--- a/src/Ring2-Core/RGEnvironmentAnnouncer.class.st
+++ b/src/Ring2-Core/RGEnvironmentAnnouncer.class.st
@@ -31,7 +31,7 @@ RGEnvironmentAnnouncer >> announce: anAnnouncement [
 { #category : #triggering }
 RGEnvironmentAnnouncer >> behaviorAdded: anRGBehavior [
 
-	self announce: (ClassAdded class: anRGBehavior category: nil)
+	self announce: (ClassAdded class: anRGBehavior)
 ]
 
 { #category : #triggering }


### PR DESCRIPTION
ClassAdded does not need the category anymore since the class knows it and we want to remove the usage of categories.

This breaks Iceberg